### PR TITLE
Bump compatibility to Foundry VTT v14

### DIFF
--- a/module.json
+++ b/module.json
@@ -6,8 +6,8 @@
   "library": "false",
   "compatibility": {
     "minimum": "12",
-    "verified": "13",
-    "maximum": "13"
+    "verified": "14",
+    "maximum": "14"
   },
   "authors": [
     {


### PR DESCRIPTION
## Summary
Single-line manifest bump to mark this module compatible with Foundry VTT v14.

## Changes
- `module.json`: `compatibility.verified` and `compatibility.maximum` bumped from `13` to `14`

## Rationale
The distributed `dist/module.js` is a configuration layer on top of `game.itempiles.API` — it only touches stable APIs: `Hooks`, `foundry.utils.getProperty` / `setProperty`, `CONFIG.DND5E.*`, `game.i18n`, and the `dnd5e.getItemContextOptions` hook. None of these changed in v14 in ways that affect this module.

A grep across `dist/module.js` for v14-breaking patterns (`MeasuredTemplate`, `ActiveEffect#changes`, `-=`/`==` updates, `foundry.prosemirror.defaultPlugins`) returned no hits.

Paired with fantasycalendar/FoundryVTT-ItemPiles#820 which adds v14 support to the Item Piles module this bridge depends on.

## Test plan
- [x] Loads in Foundry v14.359 with dnd5e 5.3.0 alongside v14-patched Item Piles — no console errors attributable to this module
- [x] `item-piles-ready` hook fires, `addSystemIntegration` completes, D&D 5e currencies/filters registered